### PR TITLE
Update Mixin docs & SASS Scaffold

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,12 +1,10 @@
 title: Oomph Grey Matter
 description: A wireframe system for quick HTML/SASS prototypes
   
-markdown: redcarpet
+markdown: kramdown
 highlighter: pygments
-redcarpet:
-  extensions: ["no_intra_emphasis", "fenced_code_blocks", "autolink", "strikethrough", "superscript", "with_toc_data"]
 
-baseurl: '/grey-matter/'
+baseurl: '/oomph-grey-matter/'
 port: 4040
 url: //jhogue.dev.oomphcloud.com
 twitter_handle: oomphinc

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,0 +1,25 @@
+# Manage navigation here instead of in an HTML file
+
+- title: "Intro"
+  href: "/"
+
+- title: "Oomph Mixins"
+  href: "mixins"
+  children:
+    - title: "Text Clamping"
+      href: "mixins/clamping"
+    - title: "Fluid Units"
+      href: "mixins/fluid-units"
+    - title: "Fluid Typography"
+      href: "mixins/fluid-type"
+    - title: "Brower Hacks"
+      href: "mixins/hacks"
+
+- title: "BS4 Grid"
+  href: "grid"
+
+- title: "All HTML"
+  href: "sample-html"
+
+- title: "Vertical Rhythm"
+  href: "sample-rhythm"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,29 +1,19 @@
 	{% assign pages = site.pages | sort:'nav-title' %}
-	<footer class="layout__foot mt-3 border-top py-2 pt-md-3 pt-lg-4">
-		<div class="container">
-			
-			<ul class="nav justify-content-center mb-2 mb-md-3 mb-lg-4" role="navigation">
-        <li class="nav-item"><a href="#" class="nav-link disabled">All pages:</a></li>
-        {% for p in pages %}
-				<li class="nav-item">
-  				<a href="{{ site.baseurl}}{{ p.permalink }}" class="nav-link{% if page.url == p.url %} active{% endif %}">{% if p.nav-title %}{{ p.nav-title }}{% else %}{{ p.title }}{% endif %}</a>
-				</li>
-				{% endfor %}
-      </ul>
-			
-			<p class="text-center small">&copy;{{ 'now' | date: '%Y' }} Oomph, Inc.</p>
-		</div>
+	<footer class="main__footer layout__foot mt-3 border-top py-2 pt-md-3 pt-lg-4">
+		<nav class="navbar navbar-expand-lg navbar-light navbar--footer">
+  		{% include navigation.html %}
+		</nav>
+		<p class="text-center small">&copy;{{ 'now' | date: '%Y' }} Oomph, Inc.</p>
 	</footer>
 
 	<div id="size"></div>
 
 	<script src="http://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+	
   {% comment %}
     If using Bootstrap Tooltips, load this file as well
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-    
-    Include all the BS4 JS modules via CDN:
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
     
     Below: 
     1. Our projects JS plugins. Cut and paste the libraries here

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,7 @@
 	<div id="top"></div>
 	
 	<header class="layout__head mb-3 mb-md-4 mb-lg-5">
-		{% include navigation.html %}
+		<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  		{% include navigation.html %}
+		</nav>
 	</header>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,22 +1,27 @@
-	{% assign pages = site.pages | sort:'nav-title' %}
-
-  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-    <a class="navbar-brand" href="{{ site.baseurl }}">GreyMatter</a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navbarNav">
-      <ul class="navbar-nav">
-        {% for p in pages %}
-    			{% unless p.permalink == '/' && unless p.permalink != '' && p.nav-title != '' && p.title != '' %}
-      		<li class="nav-item{% if page.url == p.url %} active{% endif %}">
-        		<a class="nav-link" href="{{ site.baseurl}}{{ p.permalink }}">
-          		{% if p.nav-title %}{{ p.nav-title }}{% else %}{{ p.title }}{% endif %}
-          		{% if page.url == p.url %} <span class="sr-only">(current)</span>{% endif %}
-          </a>
-      		</li>
-    		  {% endunless %}
-    		{% endfor %}
-      </ul>
-    </div>
-  </nav>
+	<a class="navbar-brand" href="{{ site.baseurl }}">GreyMatter</a>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarNav">
+    <ul class="navbar-nav ml-auto mr-auto">
+    {% for nav in site.data.navigation %}
+      {% if nav.children != null %}
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown-{{ forloop.index }}" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ nav.title }}</a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdown-{{ forloop.index }}">
+          {% for sub in nav.children %}
+          <a class="dropdown-item" href="{{ site.baseurl}}{{ sub.href }}">{{ sub.title }}{% if page.url == sub.href %} <span class="sr-only">(current)</span>{% endif %}</a>
+          {% endfor %}
+        </div>
+      </li>
+      {% else %}
+      <li class="nav-item">
+        <a class="nav-link" href="{{ site.baseurl}}{{ nav.href }}">{{ nav.title }}{% if page.url == nav.href %} <span class="sr-only">(current)</span>{% endif %}</a>
+      </li>
+      {% endif %}
+    {% endfor %}
+    </ul>
+    <span class="navbar-text ml-auto">
+      Oomph UX Prototyping & Documentation
+    </span>
+  </div>

--- a/_sass/abstracts/_index.scss
+++ b/_sass/abstracts/_index.scss
@@ -2,6 +2,7 @@
 
 // Helpful functions and mixins for every project
 @import 'functions';
+@import 'mixins/clamping';
 @import 'mixins/fluid-units';
 @import 'mixins/fluid-typography';
 @import 'mixins/hacks';
@@ -13,6 +14,7 @@
 // Project Variables — things that need to be defined before BS4
 @import 'project-vars/breakpoints';
 @import 'project-vars/colors';
+@import 'project-vars/spacing';
 @import 'project-vars/type-sizes';
 @import 'project-vars/vars';
 

--- a/_sass/abstracts/bs4-vars/_bs4-general.scss
+++ b/_sass/abstracts/bs4-vars/_bs4-general.scss
@@ -14,7 +14,7 @@
 //$enable-gradients:          false;
 //$enable-transitions:        true;
 //$enable-grid-classes:       true;
-$enable-print-styles: false;
+//$enable-print-styles:       true;
 
 
 // This variable affects the `.h-*` and `.w-*` classes.

--- a/_sass/abstracts/bs4-vars/_bs4-typography.scss
+++ b/_sass/abstracts/bs4-vars/_bs4-typography.scss
@@ -27,23 +27,23 @@ $line-height-sm: $project-lineheight-tight;
 
 // Set the base sizes — the Mobile sizes
 // The mixin should grab the value defined for "base" in our "type-sizes" map
-$h1-font-size: rem(one-type-size(h1));
-$h2-font-size: rem(one-type-size(h2));
-$h3-font-size: rem(one-type-size(h3));
-$h4-font-size: rem(one-type-size(h4));
-$h5-font-size: rem(one-type-size(h5));
-$h6-font-size: rem(one-type-size(h6));
+$h1-font-size: one-type-size(h1);
+$h2-font-size: one-type-size(h2);
+$h3-font-size: one-type-size(h3);
+$h4-font-size: one-type-size(h4);
+$h5-font-size: one-type-size(h5);
+$h6-font-size: one-type-size(h6);
 
-//$headings-margin-bottom: ($spacer / 2);
+$headings-margin-bottom: $project-vertical-rhythm;
 //$headings-font-family: inherit;
 $headings-font-weight: $font-weight-normal;
 $headings-line-height: $line-height-sm;
 //$headings-color: inherit;
 
-$display1-size: rem(one-type-size(display-1));
-$display2-size: rem(one-type-size(display-2));
-$display3-size: rem(one-type-size(display-3));
-$display4-size: rem(one-type-size(display-4));
+$display1-size: one-type-size(display-1);
+$display2-size: one-type-size(display-2);
+$display3-size: one-type-size(display-3);
+$display4-size: one-type-size(display-4);
 
 //$display1-weight: $headings-font-weight;
 //$display2-weight: $headings-font-weight;
@@ -51,10 +51,10 @@ $display4-size: rem(one-type-size(display-4));
 //$display4-weight: $headings-font-weight;
 //$display-line-height: $headings-line-height;
 
-$lead-font-size: rem(one-type-size(h3));
+$lead-font-size: one-type-size(h3);
 $lead-font-weight: $font-weight-bold;
 
-$small-font-size: rem(one-type-size(small));
+$small-font-size: one-type-size(small);
 
 //$text-muted: $gray-600;
 

--- a/_sass/abstracts/mixins/_clamping.scss
+++ b/_sass/abstracts/mixins/_clamping.scss
@@ -1,0 +1,96 @@
+/// Various ways to do line clamping
+/// @author jhogue
+///
+/// @param {String} Max-width value
+///
+/// @example scss - Usage
+///   // .element {
+///   //   @include single-line-clamp(em(240));
+///   // }
+///
+/// @example css - Output
+///   // .element {
+///   //   max-width: 15em;
+///   //   overflow: hidden;
+///   //   text-overflow: ellipsis;
+///   //   white-space: nowrap;
+///   // }
+///
+@mixin single-line-clamp($width) {
+  max-width: $width;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/// Simple approach for multi-lines
+/// @author jhogue
+///
+/// @param {Numeric} Number of lines to clamp to
+/// @param {String} Font-size
+/// @param {String} Line-height
+///
+/// @example scss - Usage
+///   // .element {
+///   //   @include multi-line-clamp(2);
+///   // }
+///
+/// @example css - Output
+///   // .element {
+///   //   position: relative;
+///   //   overflow: hidden;
+///   //   max-height: 3.125rem;
+///   //   padding-right: 1em;
+///   // }
+///   // .element::before,
+///   // .element::after {
+///   //   position: absolute;
+///   //   bottom: 0;
+///   //   right: 0;
+///   // }
+///   // .element::before {
+///   //   z-index: 2;
+///   //   content: '\2026';
+///   // }
+///   // .element::after {
+///   //   content: "";
+///   //   z-index: 1;
+///   //   width: 1em;
+///   //   height: 1em;
+///   // }
+///
+/// @example With more complicated $font-size declaration
+///   // .element {
+///   //   @include multi-line-clamp(2, rem(map-get(map-get($type-sizes, x-large), h3)));
+///   // }
+///
+@mixin multi-line-clamp($lines, $fs: $font-size-base, $lh: $line-height-base) {
+  // Set up the variables
+  $lines: $lines * 1rem;
+  $fs: strip-unit($fs);
+  $lh: strip-unit($lh);
+  
+  position: relative;
+  overflow: hidden;
+  max-height: ($lh * $fs) * $lines;
+  padding-right: 1em; // space for ellipsis
+  
+  &::before,
+  &::after {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+  }
+  
+  &::before {
+    z-index: 2;
+    content: '\2026';
+  }
+  
+  &::after {
+    content: "";
+    z-index: 1;
+    width: 1em;
+    height: 1em;
+  }
+}

--- a/_sass/abstracts/mixins/_fluid-typography.scss
+++ b/_sass/abstracts/mixins/_fluid-typography.scss
@@ -11,20 +11,27 @@
 /// @param {String} Element name [base]
 ///
 /// @example scss - Usage
-///    font-size: px(one-type-size('h1', 'x-large'));
+///    font-size: px(one-type-size('x-large', 'h1'));
 ///
 /// @example css - Output
 ///    font-size: 31px;
 ///
-@function one-type-size($element, $break: small) {
+@function one-type-size($element, $break: null, $unit: 1rem) {
+  @if $break == null {
+    // No breakpoint name is defined, so grab the first one
+    $keys: map-keys($type-sizes);
+    $break: nth($keys, 1);
+  }
   @if type-of($type-sizes) != 'map' {
     @error 'A list named $type-sizes is undefined. [Function one-type-size()]';
   }
   @if type-of(map-get($type-sizes, $break)) != 'map' {
-    @error 'Can’t reach into $type-sizes to retreive the $break [#{$break}] map. [Function one-type-size()]';
+    @error 'Can’t reach into the $type-sizes map for another map. [Function one-type-size()]';
   }
   $elementsize: map-get(map-get($type-sizes, $break), $element);
-  @return $elementsize;
+  
+  // Not sure I like this. We assume pixels in and REM/EM out with this math
+  @return strip-unit(rem($elementsize)) * $unit;
 }
 
 
@@ -32,6 +39,7 @@
 /// @author jhogue
 ///
 /// @require {map} $type-sizes
+/// @require {map} $project-breakpoints
 ///
 /// @require {function} type-of
 /// @require {function} map-keys
@@ -46,6 +54,7 @@
 /// @require {mixin} fluid-units
 ///
 /// @param {String} Element name [base]
+/// @param {String} Render mobile values [true]
 ///
 /// @example scss - Usage
 ///   @include one-element-size(h1);
@@ -65,9 +74,9 @@
 ///     }
 ///   }
 ///
-@mixin fluid-type-sizes($elem: 'base', $bootstrap: true) {
+@mixin fluid-type-sizes($elem: 'base', $mobile: true) {
   @if type-of($type-sizes) != 'map' {
-    @error 'A sass map named $type-sizes is undefined. [Mixin one-element-size()]';
+    @error 'A list named $type-sizes is undefined. [Mixin one-element-size()]';
   }
 
   // List only the keys from the $type-sizes list.
@@ -76,12 +85,12 @@
   $first-key: nth($keys, 1);
   $last-key: nth($keys, length($keys));
 
-  // Type size as REM values but unitless
-  $min-value: strip-unit(rem(one-type-size($elem, $first-key)));
-  $max-value: strip-unit(rem(one-type-size($elem, $last-key)));
+  // Change these key values into a typographic value
+  // by getting the matching key/value pair from the $type-sizes array
+  $min-value: strip-unit((one-type-size($elem, $first-key)));
+  $max-value: strip-unit((one-type-size($elem, $last-key)));
 
-  // Use the keys to grab the corresponding breakpoints
-  // Check for existence and naming convention first
+  // Use the same keys to grab the corresponding breakpoints
   @if type-of($project-breakpoints) != 'map' {
     @error 'A list named $project-breakpoints is undefined. [Mixin one-element-size()]';
   }
@@ -92,29 +101,14 @@
     @error 'Your $type-sizes map key "#{$last-key}" does not have a corresponding key in $project-breakpoints. [Mixin one-element-size()]';
   }
 
-  // We need the bp value to be expressed as REM but unitless
-  $min-vw: strip-unit(rem(map-get($project-breakpoints, $first-key)));
-  $max-vw: strip-unit(rem(map-get($project-breakpoints, $last-key)));
-  $unit: 1rem;
+  $min-vw: strip-unit(rem(bp($first-key)));
+  $max-vw: strip-unit(rem(bp($last-key)));
 
   // Finally, use this mixin to set the base size and max size within the viewport range
-
-  // If this is bootstrap, don't output the first default type size
-  @if ($bootstrap == false) {
-    font-size: calc(#{$min-value} * $unit);
-  }
-
-  // If both are the same value, don't output the media queries
-  @if map-get(map-get($type-sizes, $first-key), $elem) != map-get(map-get($type-sizes, $last-key), $elem) {
-
-    // Declare the creamy, fluid center using a media query at the min-width
-    @media (min-width: #{$min-vw * $unit}) {
-      font-size: calc((#{$min-value} * #{$unit}) + (#{$max-value} - #{$min-value}) * ((100vw - #{$min-vw * $unit}) / #{$max-vw - $min-vw}));
-    }
-
-    // Finally, stop the crazy fluidity and set the max value at the max viewport width
-    @media (min-width: #{$max-vw * $unit}) {
-      font-size: calc(#{$max-value} * #{$unit});
-    }
+  @if $min-value != $max-value {
+    // Min and Max are different, so output the crazy calc function
+    @include fluid-units('font-size', $min-value, $max-value, $min-vw, $max-vw, 1rem, $mobile);
+  } @else {
+    font-size: ($min-value * 1rem);
   }
 }

--- a/_sass/abstracts/mixins/_fluid-units.scss
+++ b/_sass/abstracts/mixins/_fluid-units.scss
@@ -1,62 +1,75 @@
 /// fluid-units() =
 /// Set a minimum value, maximum value, and use calc() to fluidly go from one to the other in between
-/// @author Indrek Paas @indrekpaas
+/// @author J. Hogue @artinruins
 /// @link http://www.sassmeister.com/gist/7f22e44ace49b5124eec
 /// @link Inspired by http://madebymike.com.au/writing/precise-control-responsive-typography/
 ///
-/// @require {function} strip-unit
+/// @require All numbers passed must be the same unit and unitless. The last parameter is the unit of the output
 ///
 /// @param {List} $properties
 ///   List one or multiple properties to assign values to
 ///
 /// @param {String} $min-value
 /// @param {String} $max-value
-///   Min/Max values for the measurement. The same units should be used (px, em, rem)
+///   Min/Max values for the measurement. Both should be unitless values.
 ///
 /// @param {String} $min-vw
 /// @param {String} $max-vw
 ///   Min/Max viewport width. Which viewport "locks" should the fluid measurements start and end at?
 ///
-/// @example scss - Usage
+/// @param {String} $unit
+///   Assumes 1rem by default
+///
+/// @example scss - Usage with CSS vars
 ///  // .element {
-///  //   @include fluid-units(padding-top padding-bottom, 1em, 4em, em(480), em(1200));
+///  //   @include fluid-units('padding-top' 'padding-bottom', 1, 3, (480/16), (1200/16), 1rem);
 ///  // }
 ///
 /// @example css - Output
 ///  // .element {
-///  //   padding-top: 1em;
-///  //   padding-bottom: 1em;
+///  //   padding-top: 1rem;
+///  //   padding-bottom: 1rem;
 ///  // }
-///  // @media (min-width: 38.75em) {
+///  // @media (min-width: 30rem) {
 ///  //   .element {
-///  //     padding-top: calc(1em + 3 * (100vw - 38.75em) / 46.25);
-///  //     padding-bottom: calc(1em + 3 * (100vw - 38.75em) / 46.25);
+///  //     padding-top: calc(1rem + (3 - 1) * (100vw - 30rem) / 35);
+///  //     padding-bottom: calc(1rem + (3 - 1) * (100vw - 30rem) / 35);
 ///  //   }
 ///  // }
-///  // @media (min-width: 85em) {
+///  // @media (min-width: 75rem) {
 ///  //   .element {
-///  //     padding-top: calc(1em + 3 * 1em);
-///  //     padding-bottom: calc(1em + 3 * 1em);
+///  //     padding-top: 3rem;
+///  //     padding-bottom: 3rem;
 ///  //   }
 ///  // }
 ///
-@mixin fluid-units($properties, $min-value, $max-value, $min-vw, $max-vw) {
+
+/// Helper function
+@function fluid-calc($min-value, $max-value, $min-vw, $max-vw, $unit: 1rem) {
+  @return calc(#{$min-value * $unit} + (#{$max-value} - #{$min-value}) * ((100vw - #{$min-vw * $unit}) / #{$max-vw - $min-vw}));
+}
+
+/// Actual mixin
+@mixin fluid-units($properties, $min-value, $max-value, $min-vw, $max-vw, $unit: 1rem, $mobile: true) {
+  
   // Mobile-first: declare the $min-value as the default for any property passed
-  @each $property in $properties {
-    #{$property}: $min-value;
+  @if ($mobile == true) {
+    @each $property in $properties {
+      #{$property}: #{$min-value * $unit};
+    }
   }
 
   // Now declare the creamy, fluid center using a media query at the min-width
-  @media (min-width: $min-vw) {
+  @media (min-width: #{$min-vw * $unit}) {
     @each $property in $properties {
-      #{$property}: calc(#{$min-value} + #{strip-unit($max-value - $min-value)} * (100vw - #{$min-vw}) / #{strip-unit($max-vw - $min-vw)});
+      #{$property}: fluid-calc($min-value, $max-value, $min-vw, $max-vw, $unit);
     }
   }
 
   // Finally, stop the crazy fluidity and set the max value at the max viewport width
-  @media (min-width: $max-vw) {
+  @media (min-width: #{$max-vw * $unit}) {
     @each $property in $properties {
-      #{$property}: $max-value;
+      #{$property}: #{$max-value * $unit};
     }
   }
 }

--- a/_sass/abstracts/mixins/_hacks.scss
+++ b/_sass/abstracts/mixins/_hacks.scss
@@ -1,12 +1,19 @@
+///
+/// Store useful Browser Hacks here
+/// Test them to pass the Linter and then document them for everyone else
+///
+/// See http://browserhacks.com/ for some inspiration when you encounter a browser that needs hacking
+///
+
 // Target old IE only — works for IE10 and 11, not newer
-@mixin for-old-ie() {
+@mixin hack-for-old-ie() {
   @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
     @content;
   }
 }
 
 // Target ANY Firefox browser
-@mixin for-any-firefox() {
+@mixin hack-for-any-firefox() {
   // stylelint-disable function-url-quotes
   @-moz-document url-prefix() {
     @content;

--- a/_sass/abstracts/mixins/_show-hide.scss
+++ b/_sass/abstracts/mixins/_show-hide.scss
@@ -1,0 +1,11 @@
+// Utilities to make hiding or showing an element quicker
+
+@mixin hide {
+  display: none;
+  visibility: hidden;
+}
+
+@mixin show($d: block) {
+  display: $d;
+  visibility: visible;
+}

--- a/_sass/abstracts/project-vars/_breakpoints.scss
+++ b/_sass/abstracts/project-vars/_breakpoints.scss
@@ -23,7 +23,7 @@ $project-maxwidths: (
   @return map-get($project-breakpoints, $bp);
 }
 
-// Breakpoints expressed in PX, math in EMs
+// Breakpoints expressed unitless in PX, math in PX because BS4 prefers that
 $project-bp-xs: px(bp(base));
 $project-bp-sm: px(bp(small));
 $project-bp-md: px(bp(medium));

--- a/_sass/abstracts/project-vars/_colors.scss
+++ b/_sass/abstracts/project-vars/_colors.scss
@@ -4,16 +4,16 @@
 
 
 $white: #fff;
-$gray-100: #f8f9fa;
-$gray-200: #e9ecef;
-$gray-300: #dee2e6;
-$gray-400: #ced4da;
-$gray-500: #adb5bd;
-$gray-600: #6c757d;
-$gray-700: #495057;
+// $gray-100: #f8f9fa;
+// $gray-200: #e9ecef;
+// $gray-300: #dee2e6;
+// $gray-400: #ced4da;
+// $gray-500: #adb5bd;
+// $gray-600: #6c757d;
+// $gray-700: #495057;
 $gray-800: #343a40;
-$gray-900: #212529;
-$black: #101010;
+// $gray-900: #212529;
+// $black: #101010;
 
 //$grays: ();
 // stylelint-disable-next-line scss/dollar-variable-default
@@ -32,16 +32,16 @@ $black: #101010;
 //  $grays
 //);
 
-$blue:    #007bff;
-$indigo:  #6610f2;
-$purple:  #6f42c1;
-$pink:    #e83e8c;
-$red:     #dc3545;
-$orange:  #fd7e14;
-$yellow:  #ffc107;
+// $blue:    #007bff;
+// $indigo:  #6610f2;
+// $purple:  #6f42c1;
+// $pink:    #e83e8c;
+// $red:     #dc3545;
+// $orange:  #fd7e14;
+// $yellow:  #ffc107;
 $green:   #28a745;
-$teal:    #20c997;
-$cyan:    #17a2b8;
+// $teal:    #20c997;
+// $cyan:    #17a2b8;
 
 //$colors: ();
 // stylelint-disable-next-line scss/dollar-variable-default
@@ -64,14 +64,14 @@ $cyan:    #17a2b8;
 //  $colors
 //);
 
-$primary:   $blue;
-$secondary: $gray-600;
-$success:   $green;
-$info:      $cyan;
-$warning:   $yellow;
-$danger:    $red;
-$light:     $gray-100;
-$dark:      $gray-800;
+// $primary:   $blue;
+// $secondary: $gray-600;
+// $success:   $green;
+// $info:      $cyan;
+// $warning:   $yellow;
+// $danger:    $red;
+// $light:     $gray-100;
+// $dark:      $gray-800;
 
 //$theme-colors: ();
 // stylelint-disable-next-line scss/dollar-variable-default

--- a/_sass/abstracts/project-vars/_spacing.scss
+++ b/_sass/abstracts/project-vars/_spacing.scss
@@ -1,0 +1,7 @@
+// Establishing some vertical rhythm for block elements
+// We use em so that they scale based on the font size of the element and breakpoint
+$project-vertical-rhythm: ($project-lineheight-base * 1rem);
+
+// Horizontal spacing
+$project-gutter: 1rem;
+

--- a/_sass/abstracts/project-vars/_vars.scss
+++ b/_sass/abstracts/project-vars/_vars.scss
@@ -13,10 +13,6 @@ $focus-outline-style: solid;
 $toolbar-fixed: 39px;
 $toolbar-tray-open: 82px;
 
-// Establishing some vertical rhythm for block elements
-// We use em so that they scale based on the font size of the element and breakpoint
-$project-vertical-rhythm: ($project-lineheight-base * 1em);
-
 // Z Indices
 $z-indices: (
   base: 1,

--- a/_sass/base/_global.scss
+++ b/_sass/base/_global.scss
@@ -2,10 +2,40 @@
 // Rules that BS4 does not ship with
 
 pre {
-  background-color: rgba($code-color, .1);  
+  background-color: rgba($code-color, 0.1);
+  border-top: 3px solid rgba($code-color, 0.5);
+  border-bottom: 3px solid rgba($code-color, 0.5);
+  line-height: 1.8;
+  padding: 1.5rem $project-gutter;
+  margin-bottom: 1.375rem;
 }
 
 // BS4 Reboot is opinionated and removes the user agent default italic style
 address {
   font-style: italic;
+}
+
+// BS4 has .text-white but no black
+.text-black {
+  color: $black;
+}
+
+// Custom globals
+.parenthetical {
+  background-color: percent-color($yellow, 25);
+  padding: 1.5rem $project-gutter 0.125rem;
+  margin-bottom: 1.625rem;
+}
+
+// Utility for Line Clamping
+.u-single-line-clamp {
+  @include single-line-clamp(100%);
+}
+
+.u-multi-line-clamp {
+  @include multi-line-clamp(2);
+}
+
+.lead.u-multi-line-clamp {
+  @include multi-line-clamp(2, rem(map-get(map-get($type-sizes, x-large), h3)));
 }

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -16,18 +16,30 @@ strong {
 
 .display-1 {
   @include fluid-type-sizes('display-1');
+  line-height: 1.105;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
 }
 
 .display-2 {
   @include fluid-type-sizes('display-2');
+  line-height: 1;
+  margin-top: 1.625rem;
+  margin-bottom: 1.5rem;
 }
 
 .display-3 {
   @include fluid-type-sizes('display-3');
+  line-height: 1.1875;
+  margin-top: 2rem;
+  margin-bottom: 1.25rem;
 }
 
 .display-4 {
   @include fluid-type-sizes('display-4');
+  line-height: 1.375;
+  margin-top: -0.5rem;
+  margin-bottom: 0.875rem;
 }
 
 // All headers and utility classes
@@ -48,6 +60,8 @@ strong {
 h1,
 .h1 {
   @include fluid-type-sizes('h1');
+  margin-top: 1.875rem;
+  margin-bottom: 1.625rem;
 }
 
 h2,
@@ -55,27 +69,45 @@ h2,
 .pull-quote__left,
 .pull-quote__right {
   @include fluid-type-sizes('h2');
+  // Vertical rhythm
+  line-height: 1.333;
+  margin-top: 2.125rem;
+  margin-bottom: 1.375rem;
 }
 
 h3,
 .h3,
 .lead {
   @include fluid-type-sizes('h3');
+  font-weight: $font-custom-weight-bold;
+  margin-top: 2.5rem;
+  margin-bottom: 1.25rem;
 }
 
 h4,
 .h4 {
   @include fluid-type-sizes('h4');
+  margin-top: -0.25rem;
+  margin-bottom: 1.5rem;
 }
 
 h5,
 .h5 {
   @include fluid-type-sizes('h5');
+  font-weight: $font-custom-weight-bold;
+  margin-top: 1.625rem;
+  margin-bottom: 0.25rem;
 }
 
 h6,
 .h6 {
   @include fluid-type-sizes('h6');
+  font-weight: $font-custom-weight-bold;
+  letter-spacing: $project-kerning;
+  line-height: 1.35;
+  margin-top: 1.625rem;
+  margin-bottom: 0.125rem;
+  text-transform: uppercase;
 }
 
 // Yes, BS4 has a .small class, but it does not follow typical naming conventions
@@ -98,7 +130,7 @@ input,
 }
 
 // Margin bottoms
-//p already declared properly via BS4
+// p already declared properly via BS4
 blockquote,
 address,
 ul,
@@ -107,21 +139,14 @@ dl {
   margin-bottom: $paragraph-margin-bottom;
 }
 
+// A little more space after list-items
+li {
+  padding-bottom: 0.125rem;
+}
+
 a,
 button {
   transition: $project-transition;
-}
-
-.display-1 {
-  margin-bottom: ($paragraph-margin-bottom / 4);
-}
-
-.display-2 {
-  margin-bottom: ($paragraph-margin-bottom / 3);
-}
-
-.display-3 {
-  margin-bottom: ($paragraph-margin-bottom / 2);
 }
 
 // Similar to BS4's .initialism, but not as small + kerning
@@ -129,33 +154,4 @@ button {
   font-size: 93.75%;
   letter-spacing: $project-kerning;
   text-transform: uppercase;
-}
-
-.initial-indent {
-  text-indent: em(36);
-
-  & + & {
-    margin-top: - $paragraph-margin-bottom;
-  }
-}
-
-.initial-cap {
-  &::first-letter {
-    float: left;
-    font-size: 500%;
-    line-height: 1;
-    margin-top: -0.125em;
-    padding-right: 1rem;
-    text-transform: uppercase; // Just in case
-
-    @include for-any-firefox {
-      margin-top: 0.0625em;
-      margin-bottom: 0.25em;
-    }
-  }
-}
-
-// BS4 has .text-white but no black
-.text-black {
-  color: $black;
 }

--- a/_sass/layout/_layout.scss
+++ b/_sass/layout/_layout.scss
@@ -2,7 +2,7 @@
 // Layout
 //
 
-// MOst of the actual layout is handled by BS4 and grid utility classes
+// Most of the actual layout is handled by BS4 and grid utility classes
 
 // Template variations
 .layout-text {

--- a/_sass/project/_index.scss
+++ b/_sass/project/_index.scss
@@ -1,3 +1,4 @@
 // Base Styles
 @import 'content';
+@import 'navbar';
 @import 'paragraphs';

--- a/_sass/project/_navbar.scss
+++ b/_sass/project/_navbar.scss
@@ -1,0 +1,8 @@
+.navbar {
+  &--footer {
+    .dropdown-menu {
+      top: auto;
+      bottom: 100%;
+    }
+  }
+}

--- a/_sass/prototyping/_code-highlight.scss
+++ b/_sass/prototyping/_code-highlight.scss
@@ -2,7 +2,7 @@
 // Pulled from https://github.com/richleland/pygments-css
 
 .highlight .hll { background-color: #ffffcc }
-.highlight  { background: #ffffff; }
+//.highlight  { background: #ffffff; }
 .highlight .c { color: #888888 } /* Comment */
 .highlight .err { color: #FF0000; background-color: #FFAAAA } /* Error */
 .highlight .k { color: #008800; font-weight: bold } /* Keyword */

--- a/_sass/prototyping/_index.scss
+++ b/_sass/prototyping/_index.scss
@@ -2,5 +2,6 @@
 @import 'code-highlight';
 @import 'fontawesome';
 @import 'header-links';
+@import 'style-guide';
 @import 'vertical-rhythm';
 @import 'viewport-size';

--- a/_sass/prototyping/_style-guide.scss
+++ b/_sass/prototyping/_style-guide.scss
@@ -1,0 +1,43 @@
+.example { 
+  position: relative; 
+  background-color: $white;
+  border: 1px solid $gray-200; 
+  padding: 1.5em 1em 0.125em; 
+  margin-bottom: 1.5em; 
+  box-shadow: 0 0 0.75em rgba(#000, 0.15); 
+
+  &:before {
+    content: 'EXAMPLE'; 
+    position: absolute; 
+    top: 0;
+    right: 0; 
+    z-index: 9999; 
+    font-family: sans-serif;
+    font-size: 0.625em;
+    letter-spacing: 0.0625em;
+    color: $white; 
+    background-color: $gray-800;
+    padding: 0.4em 0.75em 0.3em; 
+  }
+}
+
+.examplecode {
+  padding: 1.125em;
+}
+
+.example + .examplecode {
+  margin-top: -1.625em;
+}
+
+.element-caption {
+  display: block;
+}
+
+// Sample iFrame content
+.sample-fluid-units {
+  @include fluid-units('padding-top' 'padding-bottom', 0.75, 2.5, (480/16), (1180/16));
+  @include fluid-units('padding-left' 'padding-right', 1, 3, (480/16), (1180/16));
+  @include fluid-units('border-width', 0.25, 1, (480/16), (1180/16));
+  border-color: $primary;
+  border-style: solid;
+}

--- a/grid.html
+++ b/grid.html
@@ -20,7 +20,7 @@ body-class: bootstrap-grid
     margin-bottom: 0;
   }
   
-  .grid [class*="col-"] {
+  .grid [class*="col"] {
     padding-top: 1rem;
     padding-bottom: 1rem;
     background-color: rgba(86, 61, 124, .15);
@@ -41,37 +41,37 @@ body-class: bootstrap-grid
   <p>There are five tiers to the Bootstrap grid system, one for each range of devices we support. Each tier starts at a minimum viewport size and automatically applies to the larger devices unless overridden.</p>
   
   <div class="row">
+    <div class="col-4">Always .col-4</div>
     <div class="col-4">.col-4</div>
     <div class="col-4">.col-4</div>
-    <div class="col-4">.col-4</div>
   </div>
   
   <div class="row">
+    <div class="col-sm-4">Small .col-sm-4</div>
     <div class="col-sm-4">.col-sm-4</div>
     <div class="col-sm-4">.col-sm-4</div>
-    <div class="col-sm-4">.col-sm-4</div>
   </div>
   
   <div class="row">
-    <div class="col-md-4">.col-md-4</div>
+    <div class="col-md-4">Medium .col-md-4</div>
     <div class="col-md-4">.col-md-4</div>
     <div class="col-md-4">.col-md-4</div>
   </div>
   
   <div class="row">
-    <div class="col-lg-4">.col-lg-4</div>
+    <div class="col-lg-4">Large .col-lg-4</div>
     <div class="col-lg-4">.col-lg-4</div>
     <div class="col-lg-4">.col-lg-4</div>
   </div>
   
   <div class="row">
-    <div class="col-xl-4">.col-xl-4</div>
+    <div class="col-xl-4">X-Large .col-xl-4</div>
     <div class="col-xl-4">.col-xl-4</div>
     <div class="col-xl-4">.col-xl-4</div>
   </div>
   
   <h3>Three equal columns</h3>
-  <p>Get three equal-width columns <strong>starting at desktops and scaling to large desktops</strong>. On mobile devices, tablets and below, the columns will automatically stack.</p>
+  <p>Design three equal-width columns <strong>starting at medium (tablet) and scaling to large desktops</strong>. On mobile devices, tablets and below, the columns will automatically stack.</p>
   <div class="row">
     <div class="col-md-4">.col-md-4</div>
     <div class="col-md-4">.col-md-4</div>
@@ -79,27 +79,30 @@ body-class: bootstrap-grid
   </div>
   
   <h3>Three unequal columns</h3>
-  <p>Get three columns <strong>starting at desktops and scaling to large desktops</strong> of various widths. Remember, grid columns should add up to twelve for a single horizontal block. More than that, and columns start stacking no matter the viewport.</p>
+  <p>Design three columns <strong>starting at small as 2 equal columns and one large column below</strong> and at larger viewports, change it to <strong>three columns where the first two are smaller than the last</strong>. Remember, grid columns should add up to twelve for a single horizontal block. More than that, and columns start stacking no matter the viewport.</p>
   <div class="row">
-    <div class="col-md-3">.col-md-3</div>
+    <div class="col-sm-6 col-md-3">.col-sm-6 .col-md-3</div>
+    <div class="col-sm-6 col-md-3">.col-sm-6 .col-md-3</div>
     <div class="col-md-6">.col-md-6</div>
-    <div class="col-md-3">.col-md-3</div>
   </div>
   
-  <h3>Two columns</h3>
-  <p>Get two columns <strong>starting at desktops and scaling to large desktops</strong>.</p>
+  <h3>Flexbox Columns with no Widths</h3>
+  <p>Since BS4 Grid is built with Flexbox, simply adding as many columns as you want will create a grid where all columns share space equally.</p>
   <div class="row">
-    <div class="col-md-8">.col-md-8</div>
-    <div class="col-md-4">.col-md-4</div>
+    <div class="col">.col</div>
+    <div class="col">.col</div>
+    <div class="col">.col</div>
+    <div class="col">.col</div>
+    <div class="col">.col</div>
   </div>
   
   <h3>Full width, single column</h3>
-  <p class="text-warning">No grid classes are necessary for full-width elements.</p>
+  <p class="text-success">No grid classes are necessary for full-width elements.</p>
   
   <hr>
   
   <h3>Two columns with two nested columns</h3>
-  <p>Per the documentation, nesting is easy—just put a row of columns within an existing column. This gives you two columns <strong>starting at desktops and scaling to large desktops</strong>, with another two (equal widths) within the larger column.</p>
+  <p>Per the documentation, nesting is easy—just put a row of columns within an existing column. This gives you two columns <strong>starting at medium and scaling to large desktops</strong>, with another two (equal widths) within the larger column.</p>
   <p>At mobile device sizes, tablets and down, these columns and their nested columns will stack.</p>
   <div class="row">
     <div class="col-md-8">
@@ -115,8 +118,8 @@ body-class: bootstrap-grid
   <hr>
   
   <h3>Mixed: mobile and desktop</h3>
-  <p>The Bootstrap v4 grid system has five tiers of classes: xs (extra small), sm (small), md (medium), lg (large), and xl (extra large). You can use nearly any combination of these classes to create more dynamic and flexible layouts.</p>
-  <p>Each tier of classes scales up, meaning if you plan on setting the same widths for xs and sm, you only need to specify xs.</p>
+  <p>The Bootstrap v4 grid system has five tiers of classes: <code>xs</code> (extra small), <code>sm</code> (small), <code>md</code> (medium), <code>lg</code> (large), and <code>xl</code> (extra large). You can use nearly any combination of these classes to create more dynamic and flexible layouts.</p>
+  <p>Each tier of classes scales up, meaning if you plan on setting the same widths for <code>xs</code> and <code>sm</code>, you only need to specify <code>xs</code>.</p>
   <div class="row">
     <div class="col-12 col-md-8">.col-12 .col-md-8</div>
     <div class="col-6 col-md-4">.col-6 .col-md-4</div>

--- a/index.md
+++ b/index.md
@@ -5,11 +5,11 @@ nav-title: Home
 permalink: /
 ---
 
-## A prototyping kit built on Jekyll with Bootstrap 4
+## A prototyping kit built on Jekyll with Bootstrap 4.3 & Oomph UX Scaffold
 
 
 ### Bootstrap 4
-Bootstrap 4 is included in this project. It is located at `_sass/bootstrap` and includes SCSS and JS source files. To update, download the [latest Bootstrap](https://getbootstrap.com/docs/4.0/getting-started/download/) and insert it into this project at `_sass`.
+Bootstrap 4.3 is included in this project. It is located at `_sass/bootstrap` and includes SCSS and JS source files. To update, download the [latest Bootstrap](https://getbootstrap.com/docs/4.0/getting-started/download/) and insert it into this project at `_sass`.
 
 [Documentation on Bootstrap's atomic classes](https://getbootstrap.com/docs/4.0/getting-started/introduction/) is available and we highly recommend using them. Keep custom CSS to a minimum. 
 
@@ -23,19 +23,19 @@ A CDN link to the full Font Awesome set of icons in the `<head>`, located at `_i
 A base-level [Modernizr build](https://modernizr.com/download#setclasses) in included in this project in the `<head>`, located at `_includes/head.html` with source file at `_assets/js/vendor`. Update the source file to add more tests as needed. 
 
 
-## Jekyll (< v3.0.0)
+## Jekyll (< v3.8.5)
 
 ### Jekyll gives this project:
 * A built-in local development environment
 * Simple SASS asset pipeline with Autoprefixer built-in
 * Supports `.md` as well as `.html` or `.xml` files. Mix and match as needed 
 * Supports partials for repetitive elements, like header, footer and navigation 
-* Written with a clean and unobtrusive {% raw %}`{{ double brace }}`{% endraw %} syntax
-* Supports typical `if/else`, `for`, and `while` directives 
+* Written with a clean and unobtrusive {% raw %}`{{ double brace }}`{% endraw %} syntax (like Twig!)
+* Supports typical `if/else`, `for`, and `while` directives (like Twig!)
 * [Has many built in output filters](https://gist.github.com/smutnyleszek/9803727#output) to sort arrays and filter strings
 * Supports a simple date-based blog. [More details here](https://jekyllrb.com/docs/posts/). [Jekyll even supports the idea of Draft posts!](https://jekyllrb.com/docs/drafts/)
 * Supports [categories and tags](https://codinfox.github.io/dev/2015/03/06/use-tags-and-categories-in-your-jekyll-based-github-pages/) with archive pages. 
-* Built-in support for [syntax highlighting of code snippets](https://jekyllrb.com/docs/posts/#highlighting-code-snippets) using either Pygments or Rouge.
+* Built-in support for [syntax highlighting of code snippets](https://jekyllrb.com/docs/posts/#highlighting-code-snippets) using either Pygments or Rouge code color themes.
 * [Support for data files](https://jekyllrb.com/docs/datafiles/) (CSV, JSON or YAML) to drive dynamic lists of content. 
 
 
@@ -61,9 +61,12 @@ This project uses the `colorful.css` theme by default. To change, choose a style
 {% endhighlight %}
 
 
-### Cool things Jekyll templating tags do
+## Cool things Jekyll templating tags do
 
-#### Unless directive
+### Liquid templating engine has similarities to Twig
+The double brace syntax feels like Twig, and like Twig, there are powerful built-in filters. [A nice guide to the different filters available](https://github.com/Shopify/liquid/wiki/Liquid-for-Designers) can help a front-end developer or designer execute powerful options without writing PHP or Ruby. 
+
+### Unless directive
 The `unless` tag in a `forloop`: 
 
 {% highlight erb %}
@@ -72,24 +75,11 @@ The `unless` tag in a `forloop`:
 {% endraw %}
 {% endhighlight %}
 
-Forloops also support first and last built in (no counter needed!) as seen above. 
+Forloops also support `first`, `last`, and `index` (the current pointer value) built in. 
 
 
-#### Var dump
-Dump a whole variable: {% raw %}`{{ variable | json }}`{% endraw %}. 
+### Var dump
+Dump a whole variable: {% raw %}`{{ variable | inspect }}`{% endraw %}. 
 
-{% comment %}
-#### Directory scanning/globbing
-Use a Directory Plug in to loop over HTML files:
-
-	The *directory* plugin scans a directory and gives us access to the following variables:
-	file.url        # absolute path to file
-  file.name       # basename
-  file.date       # date extracted from beginning of filename, if present (optional)
-  file.slug       # basename with the date and file extension stripped off
-  file.title      # file.slug with hyphens converted to spaces, and put into Title Case
-
-  Below we loop over all files to build an example page
-
-{% raw %}{% directory path: _components/html %}{% endraw %}
-{% endcomment %}
+### Plugins
+Jekyll is open source and was created by the team at GitHub — GitHub Pages are Jekyll. There are great resources out there including [themes](https://jekyllthemes.io/) and [plugins](https://planetjekyll.github.io/plugins/) that can help jump start a project or add functionality. 

--- a/mixins/clamping.md
+++ b/mixins/clamping.md
@@ -1,0 +1,106 @@
+---
+layout: text
+title: "Mixins: Text-Clamping"
+nav-title: Text-Clamping
+permalink: mixins/clamping/
+body-class: mixins
+---
+
+What the heck is _clamping_? When a single line of text’s character display is restricted, that’s called “line-clamping” — as in, we are clamping/restricting its displayed length by the width of its container (or something else). 
+
+{% highlight SASS %}
+-sass
+-- abstracts
+--- mixins
+---- clamping.scss:
+
+@include single-line-clamp(calc(100vw - 5.5rem));
+@include multi-line-clamp(2);
+{% endhighlight %}
+
+## Examples
+
+There are two modes of clamping — single line (most common) and multi-line. A single line example might look like this: 
+
+### Single Line:
+
+<div class="example">
+  <p class="lead u-single-line-clamp">I am a single line of text but the size of the container will “clamp” the number of visible characters.</p>
+</div>
+
+```
+<p class="lead u-single-line-clamp">I am a single line of text but the size of 
+the container will “clamp” the number of visible characters.</p>
+```
+
+#### Usage:
+{% highlight SASS %}
+// Where 100% is the width. A calc() value would be acceptable as well, depending on the use case
+.u-single-line-clamp {
+  @include single-line-clamp(100%);
+}
+{% endhighlight %}
+
+#### Output
+{% highlight CSS %}
+.u-single-line-clamp {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+{% endhighlight %}
+
+### Multi-line:
+
+<div class="example">
+  <p class="lead u-multi-line-clamp">I am a single line of text but the size of the container will “clamp” the number of visible lines to a specified number by multiplying the line-height and number of desired lines to achieve a maximum container height.</p>
+</div>
+
+```
+<p class="lead u-multi-line-clamp">I am a single line of text but the size of 
+the container will “clamp” the number of visible lines to a specified number by 
+multiplying the line-height and number of desired lines to achieve a maximum 
+container height.</p>
+```
+
+**Note**: This is done is a cheesy way, CSS-only. For better results, you may want to rely on a JS solution. [CSS-Tricks has an in-depth article about the various solutions in the wild](https://css-tricks.com/line-clampin/). 
+
+#### Usage:
+{% highlight SASS %}
+// Where 2 is the number of lines we want to clamp to and
+// the crazy string is a way of grabbing the font-size of .lead
+// $font-size defaults to BS4's $font-size-base and
+// $line-height defaults to BS4's $line-height-base if not supplied
+.lead.u-multi-line-clamp {
+  @include multi-line-clamp(2, rem(map-get(map-get($type-sizes, x-large), h3)));
+}
+{% endhighlight %}
+
+Extra work has not yet been added to this mixin to make the `max-height` responsive to changes in the fluid type size. If we have a project that needs it, let's work on that (possibly with CSS custom properties to make it easier). 
+
+#### Output
+{% highlight CSS %}
+.lead.u-multi-line-clamp {
+  position: relative;
+  overflow: hidden;
+  max-height: 5.25rem;
+  padding-right: 1em;
+}
+.lead.u-multi-line-clamp::before,
+.lead.u-multi-line-clamp::after {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+}
+.lead.u-multi-line-clamp::before {
+  z-index: 2;
+  content: '\2026';
+}
+.lead.u-multi-line-clamp::after {
+  content: "";
+  z-index: 1;
+  width: 1em;
+  height: 1em;
+}
+{% endhighlight %}

--- a/mixins/fluid-type.md
+++ b/mixins/fluid-type.md
@@ -1,0 +1,153 @@
+---
+layout: text
+title: "Mixins: Fluid Typography"
+nav-title: Fluid Typography
+permalink: mixins/fluid-type/
+body-class: mixins
+---
+
+Oomph has a robust approach for Fluid — sometimes called Responsive — Typography. There are a few moving parts to getting this set up and customized for a new site. It is important to understand the moving parts, so here we go: 
+
+
+## How to Use
+
+A few files are responsible and required for Fluid Type. The [fluid-units]({{ site.baseurl }}mixins/fluid-units) mixin is leveraged for the `calc()` magic, so be sure to read about how that works first: 
+
+{% highlight SASS %}
+-sass
+// There are four mixins in two files:
+-- abstracts
+--- mixins
+---- fluid-typography.scss
+---- fluid-units.scss
+// Then there is a settings file inside abstracts:
+--- project-vars
+---- type-sizes.scss
+     // We rely on the breakpoints map present here, called $project-breakpoints
+---- breakpoints.scss
+// We apply mobile-first type sizes in Bootstrap
+--- bs4-vars
+---- bs4-typography.scss
+// Last, we apply the responsive stuff in our typography file
+-- base
+--- typography.scss
+{% endhighlight %}
+
+
+### ONE: Set some Type Sizes
+In `abstracts/project-vars/type-sizes.scss` declare our type sizes in a multi-dimensional SASS Map that correlates with the names of the breakpoints that we want to use. We use the HTML elements as names here, but these can really be anything. It is important, though, that the names of the maps be the names of the breakpoints as well. So here, we start our fluid type scaling at the `small` breakpoint and stop it at the `x-large` one. These breakpoints are the ones named in `abstracts/project-vars/breakpoints.scss`. 
+
+Map truncated below for legibility:
+
+{% highlight SASS %}
+$type-sizes: (
+  // 1.125 typographic scale base 15
+  small: (
+    base: 16,
+    h3: 20,
+    h2: 22,
+    h1: 24
+  ),
+  // 1.22 typographic scale base 18
+  x-large: (
+    base: 19,
+    h3: 30,
+    h2: 36,
+    h1: 43
+  ),
+);
+{% endhighlight %}
+
+<aside class="parenthetical">
+  <h4><i>How do I choose which values to use in Type Sizes?</i></h4>
+  <p>Most of the time, the type scale is defined by the designer. If not, we use <a href="https://docs.google.com/spreadsheets/d/1qMutuKwJsuxDAi9aID7SVLJAsU4APr405EQO_YptScg/edit#gid=1981300418">a handy Google Sheet</a> to help calculate the values of our typographic scale. </p>
+</aside>
+
+#### TWO: Set the Mobile Sizes
+In `abstracts/bs4-vars/bs4-typography.scss` declare the mobile values using the `one-type-size` mixin. REMs are default, but the mixin accepts a `$breakpoint` (the first one is the default) and a `$unit` if needed:
+{% highlight SASS %}
+// one-type-size($element, $breakpoint: null, $unit: 1rem)
+$h1-font-size: one-type-size('h1');
+$h2-font-size: one-type-size('h2');
+$h3-font-size: one-type-size('h3');
+// etc...
+{% endhighlight %}
+
+Those variables are used by Bootstrap to set the default font-size for each heading, display size, lead size, etc… If you have other named elements that are not already handled by Bootstrap, these can be declared in `typography.scss` using the more robust `fluid-type-sizes` mixin (explained next). 
+
+#### THREE: Set the Responsive Sizes
+Then, in `sass/base/typography.scss` we declare sizes again, but this time output just the media-query portion of the Fluid-Units concept with the `fluid-type-sizes` mixin. 
+
+A `` boolean flag is set to `true` by default, but if we set it to `false`, we get the entire output including the mobile sizes: 
+
+{% highlight SASS %}
+// fluid-type-sizes($element, : true)
+p {
+  @include fluid-type-sizes('base', false);
+}
+h1,
+.h1 {
+  @include fluid-type-sizes('h1');
+}
+
+h2,
+.h2 {
+  @include fluid-type-sizes('h2');
+}
+
+h3,
+.h3,
+.lead {
+  @include fluid-type-sizes('h3');
+}
+// etc...
+{% endhighlight %}
+
+This gives us the responsive fluidity that we want. Example output for the `base` and `h1` elements should result in this: 
+
+{% highlight CSS %}
+/* This one has the mobile value because we set the  flag to "false" */
+p {
+  font-size: 1rem;
+}
+@media (min-width: 38.75rem) {
+  p {
+    font-size: calc(1rem + (1.1875 - 1) * ((100vw - 38.75rem) / 36.25));
+  }
+}
+@media (min-width: 75rem) {
+  p {
+    font-size: 1.1875rem;
+  }
+}
+/* Notice we do not see the mobile size here because we set the  flag to default ("true") */
+@media (min-width: 38.75rem) {
+  h1, .h1 {
+    font-size: calc(1.5rem + (2.6875 - 1.5) * ((100vw - 38.75rem) / 36.25));
+  }
+}
+@media (min-width: 75rem) {
+  h1, .h1 {
+    font-size: 2.6875rem;
+  }
+}
+{% endhighlight %}
+
+For the `h1`, that’s a mobile font-size of 24px and a top-end desktop font-size of 43px, all expressed in REMs and with the middle viewports getting a relative calculation between those two values based on width of the viewport. 
+
+
+## Result
+
+An example iFrame with typographic content within. Resize it to see the change in type scale/size. A fluid change will not happen until our `small` breakpoint of 640px. 
+
+Note that in Safari, the changes do not happen fluidity but rather in a jumpy sort of way. 
+
+<div style="width: 322px; height:640px; min-width:322px; max-width:150%; resize:horizontal; overflow:auto; position:relative; left:50%; transform:translateX(-50%)">
+  <iframe src="{{ site.baseurl }}mixins/sample-type/" style="position: relative; z-index:-1; height:100%; width:100%; border: 1px solid #101010"></iframe>
+</div>
+
+
+## Variations
+Different projects are, well, different, so there might be some variation in mixins out there. If your project needs to deal with units in CSS Variables, the RISD Publications project has rewritten these mixins to use named declarations instead. Consult with your team mates before recreating some of that work for your own project. 
+
+## Enjoy!

--- a/mixins/fluid-units.md
+++ b/mixins/fluid-units.md
@@ -1,0 +1,96 @@
+---
+layout: text
+title: "Mixins: Fluid Units"
+nav-title: Fluid Units
+permalink: mixins/fluid-units/
+body-class: mixins
+---
+
+Why would we want “fluid units”? What are they? 
+
+**Scenario**: We have a container that we use across the entire site. On mobile there is `1rem` padding all the way around the element, at tablet size we increase it to `2rem`, and at desktop we increase it to `3rem`. In that scenario, as one increases the size of the viewport, one will see these “bumps” as the padding rules are hit and increase or decrease with the size of the viewport. 
+
+Wouldn’t it be nice if these “bumps” were removed in favor of a smooth transition from `1rem` at 480px wide to `3rem` at 1180px wide? That’s what fluid-units can do. They are programmed to scale a little by little as the viewport increases width so each viewport width gets its own calculation, and the “bumps” when a breakpoint is hit are removed.  
+
+## How to Use
+Fluid Units makes use of a complex `calc()` function. We have broken these mixins into two parts: a reusable `@function` where the magical `calc()` is contained, and a robust `@mixin` where we can apply the function to specific CSS properties: 
+
+### Fluid Calc & Fluid Units
+{% highlight SASS %}
+-sass
+-- abstracts
+--- mixins
+---- fluid-units.scss:
+@function: fluid-calc($min-value, $max-value, $min-vw, $max-vw, $unit: 1rem);
+@mixin: fluid-units($properties, $min-value, $max-value, $min-vw, $max-vw, $unit, $mobile);
+{% endhighlight %}
+
+The _Fluid Units_ mixin can be used to make **any** unit fluid. This is the basis of the concept: 
+
+1. Define some CSS properties to apply our calculations to
+1. Define a “base” size that will be output mobile-first as the default
+1. Define a “large” size that a style will “grow” to
+1. Define a small breakpoint where we want the growth to start*
+1. Define a large breakpoint that we want the growth to stop at*
+1. Define a unit to be used in `calc()` because we need one (default: 1rem)*
+1. A Boolean for whether or not to render mobile values (default: true)*
+
+_* Optional values because there are defaults set_. In `abstracts/project-vars/breakpoints.scss` we should have set default values for `$min-vw` and `$max-vw` which this function/mixin can use. It is helpful to double check, though, that these viewport measurements are in the unit that you expect.
+
+### Usage
+
+{% highlight SASS %}
+// SASS would be:
+.container {
+  @include fluid-units('padding-left' 'padding-right', 1, 3, (480/16), (1180/16), 1rem, true);
+  // Or, without the default values:
+  // @include fluid-units('padding-left' 'padding-right', 1, 3);
+}
+{% endhighlight %}
+
+In the string above we have the following parts: 
+1. `'padding-left' 'padding-right'`: A single or space-separated list of properties
+2. Minimum value of `1`: The value to start at, mobile-first
+3. Maximum value of `3`: The value to end at, desktop-last. **Both of these should be unitless!**
+4. Minimum viewport of `(480/16)`: The viewport width to start the `calc()` from
+5. Maximum viewport of `(1180/16)`: The viewport width to stop the `calc()` at. **Both of these should be unitless!** In this example we express them in pixels for legibility, but divide them by 16 to get a REM value
+6. Unit of `1rem`: A `calc()` function needs a unit to be present. In this example, all other values are unitless but expected to be REM. But if we passed pixels values through for the min, max, min-viewport, and max-viewport values, this value should be `1px`
+7. `true` Whether or not to render the Mobile value. Default is `true`. _This is here because of Bootstrap and the way in which our Fluid Typography has been set to work. Just know that if you use this mixin as shown, you can drop this declaration and rely on the default of true_
+
+{% highlight CSS %}
+// CSS would be:
+.container {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+@media (min-width: 30rem) {
+  .container {
+    padding-left: calc(1rem + (3 - 1) * (100vw - 30rem) / 38.75);
+    padding-right: calc(1rem + (3 - 1) * (100vw - 30rem) / 38.75);
+  }
+}
+@media (min-width: 73.75rem) {
+  .container {
+    padding-left: 3rem;
+    padding-right: 3rem;
+  }
+}
+{% endhighlight %}
+
+*Text version of what is happening:*
+At default/mobile size, padding left and right is `1rem`. Starting at 480px wide, the viewport width and some math start to increase that value little by little until we hit the viewport width of 1180px, at which point we stop allowing the increase and cap the padding left and right at `3rem`. 
+
+### Result
+An example iFrame with fluid spacing within. Resize it to see the change in type scale/size. A fluid change will not happen until the viewport is larger than 480px. 
+
+Note that in Safari, the changes do not happen fluidity but rather in a jumpy sort of way. 
+
+<div style="width: 322px; height:640px; min-width:322px; max-width:150%; resize:horizontal; overflow:auto; position:relative; left:50%; transform:translateX(-50%)">
+  <iframe src="{{ site.baseurl }}mixins/sample-fluid/" style="position: relative; z-index:-1; height:100%; width:100%; border: 1px solid #101010"></iframe>
+</div>
+
+## Variations
+Different projects are, well, different, so there might be some variation in functions/mixins out there. If your project needs to deal with units in CSS Variables, the RISD Publications project has rewritten this to use named declarations instead. Consult with your teammates before recreating some of that work for your own project. 
+
+## Next
+We use this concept to drive our Responsive Typography system, so read about [fluid-typography]({{ site.baseurl }}mixins/fluid-type) next. 

--- a/mixins/hacks.md
+++ b/mixins/hacks.md
@@ -1,0 +1,48 @@
+---
+layout: text
+title: "Mixins: Browser Hacks"
+nav-title: Browser Hacks
+permalink: mixins/hacks/
+body-class: mixins
+---
+
+Browser Hacks are a necessary evil sometimes. As a team, Oomph is pretty good at refactoring some code if it means avoiding a browser hack. _Maybe there is a simpler way_ should be our ethos. But then sometimes there is no way around it — one browser is being a pain and it is not worth refactoring a bunch of code to get it to play behave like everyone else. 
+
+We document the hacks that we use in this file. It can be a bit of work to get them to pass the linter, but once they do, we want to be sure that other people can use them should they need them. So please, **if you add a hack, contribute it back**! 
+
+{% highlight SASS %}
+-sass
+-- abstracts
+--- mixins
+---- hacks.scss:
+
+@include hack-for-old-ie(); { }
+@include hack-for-any-firefox() { }
+{% endhighlight %}
+
+## Example
+
+These are **content** includes which means that they do not have any parameters and you pass rules through them like you would `media-breakpoint()` mixins from Bootstrap. They pass specific rules to specific browsers: 
+
+#### Usage:
+{% highlight SASS %}
+.element {
+  @include hack-for-old-ie() {
+    height: 3rem;
+  }
+}
+{% endhighlight %}
+
+#### Output
+{% highlight CSS %}
+@media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
+  .element {
+    height: 3rem;
+  }
+}
+{% endhighlight %}
+
+
+## If you add a hack, contribute it back!
+
+We use the `hack-for-...` naming convention for legibility. It should be clear to other authors that encounter your code that this is a ruleset intended for a particular use case. As hacks are intended for a very specific browser version, please be sure to use a clear name that also let's authors know which browser version(s) this is intended for. 

--- a/mixins/sample-fluid.md
+++ b/mixins/sample-fluid.md
@@ -1,0 +1,11 @@
+---
+layout: text
+title: "Sample Fluid Units"
+nav-title: Sample Fluid Units
+permalink: mixins/sample-fluid/
+body-class: 
+---
+
+<div class="sample-fluid-units">
+  <p>In this example, the padding and the border sizes have been set to fluid units and should increase from mobile to desktop as the viewport width increases.</p>
+</div>

--- a/mixins/sample-typography.md
+++ b/mixins/sample-typography.md
@@ -1,0 +1,25 @@
+---
+layout: text
+title: "Sample Fluid Typography"
+nav-title: Sample Typography
+permalink: mixins/sample-type/
+body-class: 
+---
+
+# Heading Level 1
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+
+## Heading Level 2
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
+
+### Heading Level 3
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. 
+
+#### Heading Level 4
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+##### Heading Level 5
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+
+###### Heading Level 6
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 

--- a/sample-html.html
+++ b/sample-html.html
@@ -6,34 +6,6 @@ permalink: sample-html/
 body-class: sample-html
 ---
 
-<style>
-/* For the style guide */
-.example { 
-  position: relative; 
-  background-color: #fff;
-  border: 1px solid #e6e6e6; 
-  padding: 1em 1em 0em; 
-  margin-bottom: 1.25em; 
-  box-shadow: 0 0 .75em rgba( 0,0,0,0.15 ); 
-}
-.example:before {
-  content: 'EXAMPLE'; 
-  position: absolute; 
-  top: 0; right: 0; 
-  z-index: 9999; 
-  font-size: .75em; 
-  color: #fff; 
-  background-color: #303030;
-  padding: .4em .75em .3em; 
-} 
-.examplecode {
-  background-color: #f2f2f2;
-  padding: 1.125em;
-}
-.example + .examplecode { margin-top: -1.25em; }
-.element-caption { display: block; }
-</style>
-
 <h1 id="menu">Style Guide and Sample Code</h1>
 <p><strong>These are basic markup and typographic styles for your site and how to use them.</strong> Most of these options are available through the TinyMCE edit window in the admin, but some will require knowledge of coding HTML. </p>
 
@@ -187,7 +159,7 @@ p q r s t u v w x y z { | } ~</code></pre>
 &lt;/dl&gt;</code></pre>
 
 <h3 id="figure">Figures</h3>
-<p>Figures are usually used to refer to images:</p>
+<p>Figures are usually used to refer to images. They can also be used to wrap a Blockquote, which can be quite nice semantics:</p>
 <div class="example">
   <figure>
     <img src="http://placekitten.com/720/300" alt="The internet loves kittens">
@@ -199,7 +171,7 @@ p q r s t u v w x y z { | } ~</code></pre>
   &lt;figcaption&gt;This is a placekitten image, with supporting caption.&lt;/figcaption&gt;
 &lt;/figure&gt;</code></pre>
 
-<p>Here, a part of a poem is marked up using figure. A <code>cite</code> element surrounds the name of the text being referred to:</p>
+<p>Here, a part of a poem is marked up using figure. A <code>cite</code> element surrounds the name of the text source:</p>
 <div class="example">
   <figure>
     <p>‘Twas brillig, and the slithy toves<br>

--- a/sample-rhythm.html
+++ b/sample-rhythm.html
@@ -38,7 +38,7 @@ padding-top: 6px;</code></pre>
 	<h3>Third-Level Header <a href="#">with a Link</a> and more text to test some of the line height wrapping</h3>
 	<p>The header above is an <code>&lt;h3&gt;</code> element, which may be used for any form of page-level header which falls below the <code>h2</code> header in a document hierarchy.</p>
 	
-	<h4>Fourth-Level Header <a href="#">with a Link</a> and more text to test some of the line height wrapping and such in order to check line height on the header element itself</h4>
+	<h4>Fourth-Level Header <a href="#">with a Link</a> and more text to test some of the line height wrapping and such</h4>
 	<p>The header above is an <code>&lt;h4&gt;</code> element, which may be used for any form of page-level header which falls below the <code>h3</code> header in a document hierarchy.</p>
 	
 	<h5>Fifth-Level Header <a href="#">with a Link</a> and more text to test some of the line height wrapping and such in order to check line height on the header element itself</h5>


### PR DESCRIPTION
Getting the Grey Matter repo up to speed as a source for the Oomph SASS Scaffold. Also adding more docs to the Mixins that we have and how they should be used. A guide for how to rip out the scaffold and start a new project should be documented somewhere as well. I recently did this for a project so I will take that on as well. 

Future state for docs: 
+ Add alternative files for some of our mixins, particularly the fluid type one. We have one project that uses REMs and another that uses CSS Vars. Would be nice to be able to choose which version of the file to use from the project start. 
+ Document generally how we approach the split between BS4 vars and project vars