### PR TITLE
Add logic to prevent prepending external links with base path.

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -16,7 +16,11 @@
       </li>
       {% else %}
       <li class="nav-item">
-        <a class="nav-link" href="{{ site.baseurl}}{{ nav.href }}">{{ nav.title }}{% if page.url == nav.href %} <span class="sr-only">(current)</span>{% endif %}</a>
+        {% if nav.href | slice(0,4) == 'http' %}
+            <a class="nav-link" href="{{ nav.href }}">{{ nav.title }}</a>
+        {% else %}
+          <a class="nav-link" href="{{ site.baseurl}}{{ nav.href }}">{{ nav.title }}{% if page.url == nav.href %} <span class="sr-only">(current)</span>{% endif %}</a>
+        {% endif %}
       </li>
       {% endif %}
     {% endfor %}


### PR DESCRIPTION
The GitHub link in the top and bottom nav was broken because it was being prepended with the Jekyll `site.baseurl`. This adds logic (only for top level items) to support external links. 